### PR TITLE
Added check for headers before accessing content type

### DIFF
--- a/src/app/fetch-status.service.ts
+++ b/src/app/fetch-status.service.ts
@@ -103,7 +103,7 @@ export class FetchStatusService {
   private getStatus(response: HttpResponseBase): Status {
     let contentType = 'none';
 
-    if (response.headers.has('Content-type')) {
+    if (response.headers && response.headers.has('Content-type')) {
       contentType = response.headers.get('Content-type').split(';', 2)[0];
     }
 


### PR DESCRIPTION
This was causing the extension to stop fetching for some websites that don't include headers with the response error.