### PR TITLE
Implemented fetch on command and long term storage settings

### DIFF
--- a/src/app/chrome-link.service.ts
+++ b/src/app/chrome-link.service.ts
@@ -3,7 +3,6 @@
 
 import { Injectable, NgZone } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { FetchStatusService } from './fetch-status.service';
 import { Title } from '@angular/platform-browser';
 import { LinkData } from './interfaces';
 
@@ -27,8 +26,7 @@ export class ChromeLinkService {
 
   private parentTabId: number;
 
-  constructor(private fetchService: FetchStatusService,
-    private ngZone: NgZone, private title: Title) {
+  constructor(private ngZone: NgZone, private title: Title) {
 
     chrome.tabs.getCurrent((currTab: chrome.tabs.Tab) => {
       this.parentTabId = currTab.openerTabId;
@@ -54,8 +52,7 @@ export class ChromeLinkService {
         console.error(response.errorMessage);
       } else {
         this.ngZone.run(() => {
-          this.setLinks(response.linkList);
-          this.fetchService.fetch(response.linkList);
+          this.linkListSource.next(response.linkList);
         });
       }
     });
@@ -64,10 +61,6 @@ export class ChromeLinkService {
       this.title.setTitle(parentTab.title + ' (Link Diver)');
       this.parentSource.next(parentTab.url);
     });
-  }
-
-  private setLinks(newLinks: LinkData[]): void {
-    this.linkListSource.next(newLinks);
   }
 
   highlightLink(link: LinkData): Promise<boolean> {
@@ -85,26 +78,6 @@ export class ChromeLinkService {
         }
       });
     });
-  }
-
-  downloadLinksAsCsvFile() {
-    const data = new Blob([this.linksToString()], {type: 'text/csv'});
-    const textFile = window.URL.createObjectURL(data);
-
-    chrome.downloads.download({
-      url: textFile,
-      saveAs: true
-    });
-  }
-
-  private linksToString() {
-    const links = this.linkListSource.getValue();
-    let text = 'url, visible, tag, status, content_type\n';
-    links.forEach((link) => {
-      text += `${link.href}, ${link.visible}, ${link.tagName}, `;
-      text += `${link.status}, ${link.contentType}\n`;
-    });
-    return text;
   }
 
 }

--- a/src/app/chrome-link.service.ts
+++ b/src/app/chrome-link.service.ts
@@ -48,7 +48,6 @@ export class ChromeLinkService {
       } else {
         this.ngZone.run(() => {
           this.ccdService.updateLinks(response.linkList);
-          // this.linkListSource.next(response.linkList);
         });
       }
     });
@@ -56,7 +55,6 @@ export class ChromeLinkService {
     chrome.tabs.get(this.parentTabId, (parentTab) => {
       this.title.setTitle(parentTab.title + ' (Link Diver)');
       this.ccdService.updateParent(parentTab.url);
-      // this.parentSource.next(parentTab.url);
     });
   }
 

--- a/src/app/cross-component-data.service.ts
+++ b/src/app/cross-component-data.service.ts
@@ -23,8 +23,8 @@ export class CrossComponentDataService {
   private filterOptionsSource = new BehaviorSubject<FilterOption<any>[]>([]);
   filters$ = this.filterOptionsSource.asObservable();
 
-  private showDOMSource = new BehaviorSubject<boolean>(false);
-  showDOMSource$ = this.showDOMSource.asObservable();
+  private showElementSource = new BehaviorSubject<boolean>(false);
+  showElementSource$ = this.showElementSource.asObservable();
 
   private groupCountSource = new BehaviorSubject<GroupCount>(undefined);
   groupCount$ = this.groupCountSource.asObservable();
@@ -50,8 +50,8 @@ export class CrossComponentDataService {
     this.filterOptionsSource.next(newFilters);
   }
 
-  updateShowDOMSource(newShowSource: boolean) {
-    this.showDOMSource.next(newShowSource);
+  updateShowElementSource(newShowSource: boolean) {
+    this.showElementSource.next(newShowSource);
   }
 
   updateGroupCount(newCount: GroupCount) {

--- a/src/app/cross-component-data.service.ts
+++ b/src/app/cross-component-data.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { SortOptions, GroupCount, FilterOption, GroupByKeys } from './interfaces';
+import { SortOptions, GroupCount, FilterOption, GroupByKeys, LinkData } from './interfaces';
 
 /**
  * This service is generally responsible for passing any sort of data between
@@ -10,6 +10,9 @@ import { SortOptions, GroupCount, FilterOption, GroupByKeys } from './interfaces
   providedIn: 'root'
 })
 export class CrossComponentDataService {
+
+  private linkListSource = new BehaviorSubject<LinkData[]>([]);
+  linkList$ = this.linkListSource.asObservable();
 
   private regexArrSource = new BehaviorSubject<RegExp[]>([]);
   regexArr$ = this.regexArrSource.asObservable();
@@ -32,7 +35,14 @@ export class CrossComponentDataService {
   private expandCollapseSource = new BehaviorSubject<boolean>(false);
   expandCollapseAll$ = this.expandCollapseSource.asObservable();
 
+  private parentSource = new BehaviorSubject<string>('');
+  parent$ = this.parentSource.asObservable();
+
   constructor() { }
+
+  updateLinks(newLinks: LinkData[]) {
+    this.linkListSource.next(newLinks);
+  }
 
   updateRegex(newRegexArr: RegExp[]) {
     this.regexArrSource.next(newRegexArr);
@@ -60,6 +70,10 @@ export class CrossComponentDataService {
 
   expandCollapseAll(expand: boolean) {
     this.expandCollapseSource.next(expand);
+  }
+
+  updateParent(newParent: string) {
+    this.parentSource.next(newParent);
   }
 
 }

--- a/src/app/group-list/group-list.component.ts
+++ b/src/app/group-list/group-list.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { ChromeLinkService } from '../chrome-link.service';
 import { CrossComponentDataService } from '../cross-component-data.service';
 import { LinkData, SortOptions, GroupData, FilterOption, GroupByKeys } from '../interfaces';
 
@@ -20,11 +19,10 @@ export class GroupListComponent implements OnInit {
   links: LinkData[];
   showHeader: boolean = true;
 
-  constructor(private chromeLinkService: ChromeLinkService,
-    private ccdService: CrossComponentDataService) { }
+  constructor(private ccdService: CrossComponentDataService) { }
 
   ngOnInit(): void {
-    this.chromeLinkService.linkList$.subscribe((newLinks: LinkData[]) => {
+    this.ccdService.linkList$.subscribe((newLinks: LinkData[]) => {
       this.links = newLinks;
     });
     this.ccdService.groupingKey$.subscribe((newKey: GroupByKeys) => {

--- a/src/app/indiv-link/indiv-link.component.html
+++ b/src/app/indiv-link/indiv-link.component.html
@@ -30,6 +30,6 @@
         </li>
     </ul>
 </div>
-<P *ngIf="expand && showDOMSource">
+<P *ngIf="expand && showElementSource">
     <code>{{link.source}}</code>
 </P>

--- a/src/app/indiv-link/indiv-link.component.ts
+++ b/src/app/indiv-link/indiv-link.component.ts
@@ -16,7 +16,7 @@ export class IndivLinkComponent implements OnInit {
 
   regexArr: RegExp[];
   expand: boolean;
-  showDOMSource: boolean;
+  showElementSource: boolean;
 
   @Input() link: LinkData;
 
@@ -30,8 +30,8 @@ export class IndivLinkComponent implements OnInit {
     this.ccdService.expandCollapseAll$.subscribe((expand: boolean) => {
       this.expand = expand;
     });
-    this.ccdService.showDOMSource$.subscribe((showSource: boolean) => {
-      this.showDOMSource = showSource;
+    this.ccdService.showElementSource$.subscribe((showSource: boolean) => {
+      this.showElementSource = showSource;
     });
   }
 

--- a/src/app/input-panel/input-panel.component.ts
+++ b/src/app/input-panel/input-panel.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ChromeLinkService } from '../chrome-link.service';
+import { CrossComponentDataService } from '../cross-component-data.service';
 
 /**
  * A large parent component to hold sub-components that deal with input
@@ -13,10 +13,10 @@ export class InputPanelComponent implements OnInit {
 
   parent: string;
 
-  constructor(private chromeLinkService: ChromeLinkService) { }
+  constructor(private ccdService: CrossComponentDataService) { }
 
   ngOnInit(): void {
-    this.chromeLinkService.parent$.subscribe((str: string) => this.parent = str);
+    this.ccdService.parent$.subscribe((str: string) => this.parent = str);
   }
 
 }

--- a/src/app/interfaces.ts
+++ b/src/app/interfaces.ts
@@ -84,4 +84,3 @@ export enum SortOptions {
     LexicoAscend,
     LexicoDescend
 }
-

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -24,7 +24,7 @@
     </button>
 </mat-menu>
 
-<button *ngIf="!isFetching" mat-stroked-button (click)="fetch()">
+<button mat-stroked-button [disabled]="isFetching" (click)="fetch()">
     Fetch Links
 </button>
 <button mat-stroked-button (click)="toggleAll(true)">

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -4,13 +4,18 @@
 <mat-menu #menu="matMenu">
     <button mat-menu-item (click)="refresh()">
         <mat-icon>refresh</mat-icon>
-        <span>Refresh</span>
+        <span>Reextract Links</span>
     </button>
-    <button mat-menu-item (click)="toggle()">
+    <button mat-menu-item (click)="toggleElementSource()">
         <mat-icon>code</mat-icon>
         <span>
-            <span [innerHTML]="showDOMSource ? 'Hide' : 'Show'"></span>
-            DOM Element Source
+            {{showElementSource ? 'Hide' : 'Show'}} DOM Element Source
+        </span>
+    </button>
+    <button mat-menu-item (click)="toggleFetchOnLaunch()">
+        <mat-icon>http</mat-icon>
+        <span>
+            {{fetchOnLaunch ? 'Disable' : 'Enable'}} Auto Fetch on Launch
         </span>
     </button>
     <button mat-menu-item (click)="exportLinks()">
@@ -19,6 +24,9 @@
     </button>
 </mat-menu>
 
+<button *ngIf="!isFetching" mat-stroked-button (click)="fetch()">
+    Fetch Links
+</button>
 <button mat-stroked-button (click)="toggleAll(true)">
     Expand All
 </button>

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -79,7 +79,7 @@ export class OptionsComponent implements OnInit {
   }
 
   exportLinks() {
-    const data = new Blob([this.linksToString()], {type: 'text/csv'});
+    const data = new Blob([this.linksToString()], { type: 'text/csv' });
     const textFile = window.URL.createObjectURL(data);
 
     chrome.downloads.download({
@@ -99,7 +99,6 @@ export class OptionsComponent implements OnInit {
   }
 
   fetch() {
-    console.log('Fetching', this.links);
     this.fetchService.fetch(this.links);
     this.isFetching = true;
   }

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -47,7 +47,8 @@ export class OptionsComponent implements OnInit {
         this.ccdService.updateShowElementSource(init.showElementSource);
         this.chromeLinkService.linkList$.subscribe((links: LinkData[]) => {
           this.links = links;
-          if (init.fetchOnLaunch) {
+          this.isFetching = false;
+          if (this.fetchOnLaunch) {
             this.fetch();
           }
         });

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -45,7 +45,7 @@ export class OptionsComponent implements OnInit {
         this.fetchOnLaunch = init.fetchOnLaunch;
         this.showElementSource = init.showElementSource;
         this.ccdService.updateShowElementSource(init.showElementSource);
-        this.chromeLinkService.linkList$.subscribe((links: LinkData[]) => {
+        this.ccdService.linkList$.subscribe((links: LinkData[]) => {
           this.links = links;
           this.isFetching = false;
           if (this.fetchOnLaunch) {

--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -1,7 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+// eslint-disable-next-line spaced-comment
+/// <reference types="chrome"/>
+
+import { Component, OnInit, NgZone } from '@angular/core';
 import { ChromeLinkService } from '../chrome-link.service';
 import { CrossComponentDataService } from '../cross-component-data.service';
-import { SortOptions } from '../interfaces';
+import { SortOptions, LinkData } from '../interfaces';
+import { FetchStatusService } from '../fetch-status.service';
 
 /**
  * Contains two buttons allowing the user to expand each link or collapse each
@@ -14,8 +18,11 @@ import { SortOptions } from '../interfaces';
 })
 export class OptionsComponent implements OnInit {
 
-  showDOMSource: boolean = false;
+  links: LinkData[];
+  showElementSource: boolean;
   order: SortOptions;
+  isFetching: boolean;
+  fetchOnLaunch: boolean;
   sortOptions = [
     {val: SortOptions.DOM, display: 'DOM'},
     {val: SortOptions.DOMReverse, display: 'DOM (Reverse)'},
@@ -24,9 +31,29 @@ export class OptionsComponent implements OnInit {
   ];
 
   constructor(private ccdService: CrossComponentDataService,
-    private chromeLinkService: ChromeLinkService) { }
+    private chromeLinkService: ChromeLinkService,
+    private fetchService: FetchStatusService,
+    private ngZone: NgZone) { }
 
-  ngOnInit(): void { }
+  ngOnInit(): void {
+
+    chrome.storage.sync.get({
+      showElementSource: false,
+      fetchOnLaunch: false
+    }, (init) => {
+      this.ngZone.run(() => {
+        this.fetchOnLaunch = init.fetchOnLaunch;
+        this.showElementSource = init.showElementSource;
+        this.ccdService.updateShowElementSource(init.showElementSource);
+        this.chromeLinkService.linkList$.subscribe((links: LinkData[]) => {
+          this.links = links;
+          if (init.fetchOnLaunch) {
+            this.fetch();
+          }
+        });
+      });
+    });
+  }
 
   toggleAll(expand: boolean) {
     this.ccdService.expandCollapseAll(expand);
@@ -40,13 +67,40 @@ export class OptionsComponent implements OnInit {
     this.chromeLinkService.requestLinkData();
   }
 
-  toggle() {
-    this.showDOMSource = !this.showDOMSource;
-    this.ccdService.updateShowDOMSource(this.showDOMSource);
+  toggleElementSource() {
+    this.showElementSource = !this.showElementSource;
+    this.ccdService.updateShowElementSource(this.showElementSource);
+    chrome.storage.sync.set({ showElementSource: this.showElementSource });
+  }
+
+  toggleFetchOnLaunch() {
+    this.fetchOnLaunch = !this.fetchOnLaunch;
+    chrome.storage.sync.set({ fetchOnLaunch: this.fetchOnLaunch });
   }
 
   exportLinks() {
-    this.chromeLinkService.downloadLinksAsCsvFile();
+    const data = new Blob([this.linksToString()], {type: 'text/csv'});
+    const textFile = window.URL.createObjectURL(data);
+
+    chrome.downloads.download({
+      url: textFile,
+      saveAs: true
+    });
   }
 
+  private linksToString() {
+    const links = this.links;
+    let text = 'url, visible, tag, status, content_type\n';
+    links.forEach((link) => {
+      text += `${link.href}, ${link.visible}, ${link.tagName}, `;
+      text += `${link.status}, ${link.contentType}\n`;
+    });
+    return text;
+  }
+
+  fetch() {
+    console.log('Fetching', this.links);
+    this.fetchService.fetch(this.links);
+    this.isFetching = true;
+  }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,5 +14,5 @@
             "css": ["assets/highlight.css"]
         }
     ],
-    "permissions": ["activeTab", "contextMenus", "downloads"]
+    "permissions": ["activeTab", "contextMenus", "downloads", "storage"]
 }


### PR DESCRIPTION
Changes fetching so that is does not happen automatically, instead can be triggered with a fetch button or by turning on the fetch on launch option.

To support this option we introduce the chrome storage API in order to save user settings like these for the longer term. With this new support for persistent settings, this branch also makes the showElementSource a persistent setting.

Additionally since the fetching logic is now largely centered around the options component, it is now the one responsible for calling fetchService, moving unnecessary responsibilities away from chromeLinkService. In that spirit we also move the exportLinks functionality to the options component and away from the chromeLinkService since the options component already has access to the links, is using the chrome API, and contains the save links button. Additionally this gives chromeLinkService a much more concrete and unified purpose, which is to interact with the content script to extract links.