### PR TITLE
Shorten metadata description

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Link Diver",
     "version": "1.3",
-    "description": "Link Diver is a feature-rich tool that allows you to view all of the links on a webpage. With Link Diver you can filter links by a regular expression, highlight the links on the original page, and much more! ",
+    "description": "Link Diver is a feature-rich tool that allows you to view all of the links on a webpage.",
     "manifest_version": 2,
     "browser_action": {},
     "background" : {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Link Diver",
     "version": "1.3",
-    "description": "Link Diver is a feature-rich tool that allows you to view all of the links on a webpage.",
+    "description": "Link Diver is a feature-rich tool that allows you to view all of the links on a webpage and much more!",
     "manifest_version": 2,
     "browser_action": {},
     "background" : {


### PR DESCRIPTION
There is a word limit in metadata description that we need to follow if we want to publish it in chrome web store